### PR TITLE
Update tar dependency to fix security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4557,9 +4557,9 @@
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "requires": {
         "block-stream": "*",
         "fstream": "^1.0.2",


### PR DESCRIPTION
Based on this vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2018-20834

Updated package-lock.json using this advice: https://github.com/sass/node-sass/issues/2625#issuecomment-482519446

Ran npm audit and found no vulnerabilities.